### PR TITLE
Enable title and msg text alignment for materialDialog

### DIFF
--- a/lib/material_dialogs.dart
+++ b/lib/material_dialogs.dart
@@ -34,8 +34,10 @@ class Dialogs {
 
   /// [title] your dialog title
   /// [titleStyle] your dialog title style
+  /// [titleAlign] your dialog title alignment
   /// [msg] your dialog description message
   /// [msgStyle] your dialog description style
+  /// [msgAlign] your dialog description alignment
 
   /// [actions] Widgets to display a row of buttons after the [msg] widget.
   /// [onClose] used to listen to dialog close events.
@@ -57,6 +59,8 @@ class Dialogs {
     ShapeBorder dialogShape = dialogShape,
     TextStyle titleStyle = titleStyle,
     TextStyle? msgStyle,
+    TextAlign? titleAlign,
+    TextAlign? msgAlign,
     Color color = bcgColor,
   }) async {
     await showDialog<String>(
@@ -79,6 +83,8 @@ class Dialogs {
             customView: customView,
             titleStyle: titleStyle,
             msgStyle: msgStyle,
+            titleAlign: titleAlign,
+            msgAlign: msgAlign,
             color: color,
           ),
         );

--- a/lib/widgets/dialogs/dialog_widget.dart
+++ b/lib/widgets/dialogs/dialog_widget.dart
@@ -14,6 +14,8 @@ class DialogWidget extends StatelessWidget {
     this.customView = const SizedBox(),
     this.titleStyle,
     this.msgStyle,
+    this.titleAlign,
+    this.msgAlign,
     this.color,
   });
 
@@ -38,6 +40,12 @@ class DialogWidget extends StatelessWidget {
   /// [animation] lottie animations path
   final TextStyle? msgStyle;
 
+  /// [titleAlign] dialog title text alignment
+  final TextAlign? titleAlign;
+
+  /// [textAlign] dialog description text alignment
+  final TextAlign? msgAlign;
+
   /// [color] dialog's backgorund color
   final Color? color;
 
@@ -61,6 +69,7 @@ class DialogWidget extends StatelessWidget {
                 child: Text(
                   title!,
                   style: titleStyle,
+                  textAlign: titleAlign,
                 ),
               )
             : SizedBox(
@@ -72,6 +81,7 @@ class DialogWidget extends StatelessWidget {
                 child: Text(
                   msg!,
                   style: msgStyle,
+                  textAlign: msgAlign,
                 ),
               )
             : SizedBox(


### PR DESCRIPTION
For my own project, I added `titleAlign` and `msgAlign` named argument to materialDialog because I was using msg that would span more than one line.

This may be helpful for others too.